### PR TITLE
Allows to manually send errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,8 @@ Please refer to Sentry [documentation](https://docs.sentry.io/) to create a new 
 
 One you have it, you have to provide the DSN to the plugin using one of the following method.
 
-#### Using the secrets Vault
-
-You can store the DSN inside the [Vault](https://docs.kuzzle.io/core/2/guides/essentials/secrets-vault/) under the key `sentry.dsn`:
-
-```json
-{
-  "sentry": {
-    "dsn": "https://foo42bar21baz84@sentry.io/42424242"
-  }
-}
-```
-
-You can use [kourou](https://github.com/kuzzleio/kourou/#kourou-vaultadd-secrets-file-key-value) to add it directly to a new or existing secrets file:
-
-```bash
-$ npm install -g kourou
-
-$ kourou vault:add secrets.enc.json sentry.dsn https://foo42bar21baz84@sentry.io/42424242 --vault-key vault-password
-```
-
-#### Using environment variable
-
-You can set the `SENTRY_DSN` environment variable:
+ - `SENTRY_DSN` environment variable 
+ - `plugins.sentry.dsn` key in Kuzzle configuration file
 
 ## Usage
 
@@ -45,11 +24,110 @@ It will send the error to Sentry alongside with other useful informations like:
 
 Finally, is adds a [Sentry tag](https://docs.sentry.io/enriching-error-data/context/?platform=javascript#tagging-events) containing the controller and action name to quickly identify related events.
 
-### Filtered values
+## Configuration
 
-Any sensitive information will be filtered in the Sentry report. This include password and authentication tokens.
+You can configure the plugin by using [Kuzzle configuration file](https://docs.kuzzle.io/core/2/guides/essentials/configuration/).  
 
-### Extended API
+### Sentry environment
+
+It's possible to define the [Sentry environment](https://docs.sentry.io/enriching-error-data/environments/) to bring even more context to catched errors.
+
+```js
+
+{
+  // kuzzle configuration file
+  "plugins": {
+    "sentry": {
+      "environment": "staging"
+    }
+  }
+}
+```
+
+### Ignore errors
+
+You can define errors that will be ignored and thus not send to Sentry.  
+
+You can filter errors either by [status](https://docs.kuzzle.io/core/2/api/essentials/errors/handling/) or by [id](https://docs.kuzzle.io/core/2/api/essentials/errors/codes/).  
+
+Theses filters can be defined in the configuration file:
+```js
+{
+  // kuzzle configuration file
+  "plugins": {
+    "sentry": {
+      "ignore": {
+        "ids": [
+          "security.token.verification_error",
+          "security.token.expired"
+        ],
+        "statuses": [ 401, 403 ]
+      } 
+    }
+  }
+}
+```
+
+### Filter sensitive values
+
+Any sensitive information will be filtered in the Sentry report. This include password and authentication tokens.  
+
+By default, those values are:
+ - `context.token._id`: contain the authentication token
+ - `context.token.jwt`: authentication token
+ - `input.jwt`: authentication token
+
+### Exclude Sentry integrations
+
+You can exclude default Sentry integration by providing their name in the configuration.  
+
+```js
+{
+  // kuzzle configuration file
+  "plugins": {
+    "sentry": {
+      "excludeIntegrations": [
+        "Http",
+        "Console"
+      ]
+    }
+  }
+}
+```
+
+### Configuration example
+
+```js
+{
+  // kuzzle configuration file
+  "plugins": {
+    "sentry": {
+      // DSN
+      "dsn": "https://214284...@sentry.io/214284..."
+
+      // Sentry environment
+      "environment": "staging",
+
+      // ignore specific errors
+      "ignore": {
+        "ids": [
+          "security.token.verification_error",
+          "security.token.expired"
+        ],
+        "statuses": [ 401, 403 ]
+      },
+
+      // Exclude Sentry default integrations
+      "excludeIntegrations": [
+        "Http",
+        "Console"
+      ]
+    }    
+  }
+}
+```
+
+## Extended API
 
 This plugin also expose an API method in order to enable or disable sending events to Sentry.
 

--- a/config/kuzzlerc
+++ b/config/kuzzlerc
@@ -1,0 +1,16 @@
+{
+  "plugins": {
+    "sentry": {
+      "dsn": "",
+      "environment": "production",
+      "ignore": {
+        "ids": [],
+        "statuses": [ 401, 403 ]
+      },
+      "excludeIntegrations": [
+        "Http",
+        "Console"
+      ]
+    }
+  }
+}

--- a/config/kuzzlerc
+++ b/config/kuzzlerc
@@ -5,12 +5,13 @@
       "environment": "production",
       "ignore": {
         "ids": [],
-        "statuses": [ 401, 403 ]
+        "statuses": []
       },
       "excludeIntegrations": [
         "Http",
         "Console"
-      ]
+      ],
+      "sensitiveValues": []
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - kuzzle_services__memoryStorage__node__host=redis
       - NODE_ENV=development
       - DEBUG=kuzzle:plugins
+      - KUZZLE_ENV
       - SENTRY_DSN
 
   redis:

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,26 +3,38 @@ const _ = require('lodash');
 
 class SentryPlugin {
   constructor () {
-    this.config = null;
+    this.config = {
+      dsn: null,
+      environment: 'default',
+      ignore: {
+        ids: [],
+        statuses: [ 401, 403 ]
+      },
+      excludeIntegrations: [
+        "Http",
+        "Console"
+      ]
+    };
+
     this.context = null;
 
     this.ready = false;
-    this.enabled = false;
+    this.enabled = true;
   }
 
   init (config, context) {
-    this.config = config;
+    this.config = { ...this.config, ...config};
     this.context = context;
 
     this.hooks = {
-      'request:onError': request => {
-        if (this.enabled) {
-          this._sendPayload(request);
-        }
-      }
+      'request:onError': 'sendRequest'
     };
 
     this.controllers = {
+      send: {
+        request: 'sendRequest',
+        generic: 'sendGeneric'
+      },
       admin: {
         switch: 'switch'
       }
@@ -46,40 +58,96 @@ class SentryPlugin {
   }
 
   _initSentry () {
-    const { sentry } = this.context.secrets;
-    const sentryDsn = process.env.SENTRY_DSN || sentry.dsn;
+    const dsn = process.env.SENTRY_DSN || this.config.dsn;
 
-    if (sentryDsn) {
-      Sentry.init({ dsn: sentryDsn, beforeSend: this._beforeSend.bind(this) });
-      this.ready = true;
-    }
-    else {
-      this.context.log.warn('Unable to initialize Sentry. Sentry dsn is missing from env (SENTRY_DSN) and Vault (sentry.dsn)');
-    }
-  }
+    if (! dsn) {
+      this.context.log.warn('Sentry DSN key not found. Set "plugins.sentry.dsn" in kuzzlerc or SENTRY_DSN in env.');
 
-  _sendPayload (request) {
-    if (! this.ready) {
       return;
     }
 
-    // Don't log unauthorized or forbidden errors
-    if (request.error.status === 401 || request.error.status === 403) {
+    const environment = process.env.KUZZLE_ENV || this.config.environment;
+
+    if (! this.config.environment) {
+      this.context.log.warn('KUZZLE_ENV or "config.environment" not set. Sentry errors can not be contextualized by environment.');
+    }
+    Sentry.init({
+      dsn,
+      environment,
+      normalizeDepth: 6,
+      beforeSend: this._beforeSend.bind(this),
+      integrations: integrations => {
+        return integrations.filter(integration => (
+          ! this.config.excludeIntegrations.includes(integration.name)
+        ));
+      }
+    });
+
+    this.ready = true;
+    this.context.log.info(`Sentry loaded with environment "${environment}"`);
+  }
+
+  async sendGeneric (request) {
+    const { error, tags, extras, request: originalRequest } = _.get(request, 'input.body', {});
+
+    if (! this.ready || ! this.enabled) {
       return;
     }
 
     Sentry.withScope(function (scope) {
-      scope.setUser({ id: request.context.user._id });
+      scope.setUser({ id: _.get(originalRequest, 'context.user._id') });
 
       scope.setTag(
         'controller:action',
-        `${request.input.controller}:${request.input.action}`);
+        `${_.get(originalRequest, 'input.controller')}:${_.get(originalRequest, 'input.action')}`);
 
-      scope.setExtra('input', request.input);
-      scope.setExtra('context', request.context);
-      scope.setExtra('error', request.error);
+      scope.setExtra('requestId', _.get(originalRequest, 'id'));
+      scope.setExtra('input', _.get(originalRequest, 'input'));
+      scope.setExtra('context', _.get(originalRequest, 'context'));
+      scope.setExtra('error', _.get(originalRequest, 'error'));
 
-      Sentry.captureException(request.error);
+      for (const [key, value] of Object.entries(tags || {})) {
+        scope.setTag(key, value);
+      }
+
+      for (const [key, value] of Object.entries(extras || {})) {
+        try {
+          scope.setExtra(key, JSON.parse(value));
+        }
+        catch (error) {
+          scope.setExtra(key, value);
+        }
+      }
+
+      scope.setExtra('additionalError', error);
+
+      Sentry.captureException(error);
+    });
+  }
+
+  async sendRequest (request) {
+    if (! this.ready || ! this.enabled) {
+      return;
+    }
+
+    const errorName = _.get(request, 'error.name');
+    if (errorName !== 'PluginImplementationError') {
+      return;
+    }
+
+    Sentry.withScope(function (scope) {
+      scope.setUser({ id: _.get(request, 'context.user._id') });
+
+      scope.setTag(
+        'controller:action',
+        `${_.get(request, 'input.controller')}:${_.get(request, 'input.action')}`);
+
+      scope.setExtra('requestId', _.get(request, 'id'));
+      scope.setExtra('input', _.get(request, 'input'));
+      scope.setExtra('context', _.get(request, 'context'));
+      scope.setExtra('error', _.get(request, 'error'));
+
+      Sentry.captureException(_.get(request, 'error'));
     });
   }
 
@@ -88,6 +156,8 @@ class SentryPlugin {
     this._filterExtra(event, 'context.token._id');
     this._filterExtra(event, 'context.token.jwt');
     this._filterExtra(event, 'input.jwt\u200b');
+
+    return event;
   }
 
   _filterExtra (event, key) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,18 +8,23 @@ class SentryPlugin {
       environment: 'default',
       ignore: {
         ids: [],
-        statuses: [ 401, 403 ]
+        statuses: []
       },
       excludeIntegrations: [
         "Http",
         "Console"
-      ]
+      ],
+      sensitiveValues: []
     };
 
     this.context = null;
 
     this.ready = false;
     this.enabled = true;
+  }
+
+  get sendOnlyPluginErrors () {
+    return this.config.ignore.statuses.length === 0 && this.config.ignore.ids.length === 0
   }
 
   init (config, context) {
@@ -32,7 +37,6 @@ class SentryPlugin {
 
     this.controllers = {
       send: {
-        request: 'sendRequest',
         generic: 'sendGeneric'
       },
       admin: {
@@ -88,23 +92,22 @@ class SentryPlugin {
   }
 
   async sendGeneric (request) {
-    const { error, tags, extras, request: originalRequest } = _.get(request, 'input.body', {});
+    const { error, tags, extras, request } = request.input.body || {};
 
     if (! this.ready || ! this.enabled) {
       return;
     }
 
     Sentry.withScope(function (scope) {
-      scope.setUser({ id: _.get(originalRequest, 'context.user._id') });
+      if (request) {
+        scope.setUser({ id: _.get(request, 'context.user._id') });
 
-      scope.setTag(
-        'controller:action',
-        `${_.get(originalRequest, 'input.controller')}:${_.get(originalRequest, 'input.action')}`);
+        scope.setTag(
+          'controller:action',
+          `${_.get(request, 'input.controller')}:${_.get(request, 'input.action')}`);
 
-      scope.setExtra('requestId', _.get(originalRequest, 'id'));
-      scope.setExtra('input', _.get(originalRequest, 'input'));
-      scope.setExtra('context', _.get(originalRequest, 'context'));
-      scope.setExtra('error', _.get(originalRequest, 'error'));
+        scope.setExtra('request', request.serialize());
+      }
 
       for (const [key, value] of Object.entries(tags || {})) {
         scope.setTag(key, value);
@@ -119,35 +122,8 @@ class SentryPlugin {
         }
       }
 
-      scope.setExtra('additionalError', error);
 
       Sentry.captureException(error);
-    });
-  }
-
-  async sendRequest (request) {
-    if (! this.ready || ! this.enabled) {
-      return;
-    }
-
-    const errorName = _.get(request, 'error.name');
-    if (errorName !== 'PluginImplementationError') {
-      return;
-    }
-
-    Sentry.withScope(function (scope) {
-      scope.setUser({ id: _.get(request, 'context.user._id') });
-
-      scope.setTag(
-        'controller:action',
-        `${_.get(request, 'input.controller')}:${_.get(request, 'input.action')}`);
-
-      scope.setExtra('requestId', _.get(request, 'id'));
-      scope.setExtra('input', _.get(request, 'input'));
-      scope.setExtra('context', _.get(request, 'context'));
-      scope.setExtra('error', _.get(request, 'error'));
-
-      Sentry.captureException(_.get(request, 'error'));
     });
   }
 
@@ -156,6 +132,13 @@ class SentryPlugin {
     this._filterExtra(event, 'context.token._id');
     this._filterExtra(event, 'context.token.jwt');
     this._filterExtra(event, 'input.jwt\u200b');
+    this._filterExtra(event, 'input.body.password');
+
+    for (const sensitiveValue of this.config.sensitiveValues) {
+      if (_.get(event, sensitiveValue)) {
+        _.set(event, sensitiveValue, '[Filtered');
+      }
+    }
 
     return event;
   }


### PR DESCRIPTION
## What does this PR do ?

Allows to send errors manually by calling `sentry/send:generic`

### Other changes
 
- Filter non 500 errors 
- Filter console and http breadcrumbs
- Add custom sensitive values filters