### PR TITLE
Fix SyntaxError: Identifier request has already been declared

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,6 @@
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,8 +91,8 @@ class SentryPlugin {
     this.context.log.info(`Sentry loaded with environment "${environment}"`);
   }
 
-  async sendGeneric (request) {
-    const { error, tags, extras, request } = request.input.body || {};
+  async sendGeneric (req) {
+    const { error, tags, extras, request } = req.input.body || {};
 
     if (! this.ready || ! this.enabled) {
       return;


### PR DESCRIPTION
I ran into this issue while starting a Kuzzle instance with this plugin

<img width="1433" alt="Screenshot 2020-08-05 at 15 45 53" src="https://user-images.githubusercontent.com/10114634/89420305-d039b180-d732-11ea-92bd-d54ec571aefe.png">

This PR adresses this issue.

I don't know how to test it, would you mind showing it to me first.
